### PR TITLE
custom signal to terminate a certain instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ optional arguments:
 
 ### Layers
 
-The window will appear on the top or bottom layer, according to the `-l` | `--layer` argument value (1 for bottom by default).
-You may switch layers by sending `SIGUSR1` [signal](https://man7.org/linux/man-pages/man7/signal.7.html)
-to the `nwg-wrapper` process, e.g. like this:
+The window will appear on the top or bottom layer, according to the `-l` | `--layer` argument value (1 for bottom by 
+default). You may switch between the bottom layer and the layer you selected with the `-l` argument by sending `SIGUSR1` 
+[signal](https://man7.org/linux/man-pages/man7/signal.7.html) to the `nwg-wrapper` process, e.g. like this:
 
 `pkill -f -10 nwg-wrapper`
 
@@ -108,6 +108,20 @@ or:
 `pkill -f -USR2 nwg-wrapper`
 
 You can choose a different signal number with the `-sv | --sig_visibility` argument.
+
+### Custom quit signal
+
+Sometimes you may need to terminate a certain nwg-wrapper instance (see [#5](https://github.com/nwg-piotr/nwg-wrapper/issues/5)).
+You may choose a custom signal with the `-sq` | `--sig_quit` argument.
+
+Sample script to show the wrapper over swaylock and kill it when the screen gets unlocked, w/o killing other instances:
+
+```bash
+#!/bin/bash
+
+nwg-wrapper -s swaylock-time.sh -o eDP-1 -r 1000 -c timezones.css -p right -mr 50 -a start -mt 0 -j right -l 3 -sq 31 &
+sleep 0.5 && swaylock --image '/home/piotr/Obrazy/Wallpapers/wallhaven-zmrdry-1920x1080.jpg' && pkill -f -31 nwg-wrapper
+```
 
 ### Sample usage
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,9 @@ rm /usr/bin/nwg-wrapper
 
 ```text
 $ nwg-wrapper -h
-usage: nwg-wrapper [-h] [-s SCRIPT | -t TEXT] [-c CSS] [-o OUTPUT] [-p POSITION] [-a ALIGNMENT]
-                   [-j JUSTIFY] [-mt MARGIN_TOP] [-mb MARGIN_BOTTOM] [-ml MARGIN_LEFT]
-                   [-mr MARGIN_RIGHT] [-l LAYER] [-sl SIG_LAYER] [-sv SIG_VISIBILITY] [-r REFRESH]
-                   [-v]
+usage: nwg-wrapper [-h] [-s SCRIPT | -t TEXT] [-c CSS] [-o OUTPUT] [-p POSITION] [-a ALIGNMENT] [-j JUSTIFY]
+                   [-mt MARGIN_TOP] [-mb MARGIN_BOTTOM] [-ml MARGIN_LEFT] [-mr MARGIN_RIGHT] [-l LAYER]
+                   [-sl SIG_LAYER] [-sv SIG_VISIBILITY] [-sq SIG_QUIT] [-r REFRESH] [-v]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -75,9 +74,11 @@ optional arguments:
   -l LAYER, --layer LAYER
                         initial Layer: 1 for bottom, 2 for top; 1 if no value given
   -sl SIG_LAYER, --sig_layer SIG_LAYER
-                        Signal number for Layer switching
+                        Signal number for Layer switching; default: 10
   -sv SIG_VISIBILITY, --sig_visibility SIG_VISIBILITY
-                        Signal number for toggling Visibility
+                        Signal number for toggling Visibility; default: 12
+  -sq SIG_QUIT, --sig_quit SIG_QUIT
+                        custom Signal number to Quit the wrapper instance; default: 2
   -r REFRESH, --refresh REFRESH
                         Refresh rate in milliseconds; 0 (no refresh) if no value given
   -v, --version         display version information

--- a/nwg_wrapper/main.py
+++ b/nwg_wrapper/main.py
@@ -34,7 +34,7 @@ inner_box_width = 0
 inner_box = Gtk.Box()
 window = None
 layer = 1
-args = None
+args = argparse.Namespace
 
 
 def signal_handler(sig, frame):
@@ -43,8 +43,11 @@ def signal_handler(sig, frame):
         desc = {2: "SIGINT", 15: "SIGTERM"}
         print("Terminated with {}".format(desc[sig]))
         Gtk.main_quit()
+    elif sig == args.sig_quit:
+        print("Terminated with a custom signal ({})".format(sig))
+        Gtk.main_quit()
     elif sig == args.sig_layer:
-        layer = 1 if layer == 2 else 2
+        layer = 1 if layer == args.layer else args.layer
         GtkLayerShell.set_layer(window, layer)
     elif sig == args.sig_visibility:
         if window.is_visible():
@@ -197,13 +200,19 @@ def main():
                         "--sig_layer",
                         type=int,
                         default=10,
-                        help="Signal number for Layer switching")
+                        help="Signal number for Layer switching; default: 10")
 
     parser.add_argument("-sv",
                         "--sig_visibility",
                         type=int,
                         default=12,
-                        help="Signal number for toggling Visibility ")
+                        help="Signal number for toggling Visibility; default: 12")
+
+    parser.add_argument("-sq",
+                        "--sig_quit",
+                        type=int,
+                        default=2,
+                        help="custom Signal number to Quit the wrapper instance; default: 2")
 
     parser.add_argument("-r",
                         "--refresh",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-wrapper',
-    version='0.0.3',
+    version='0.1.0',
     description='Wrapper to display script output or text file content on desktop in wlroots-based compositors',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Added the `-sq` | `--sig_quit` argument, which allows to define a custom signal to terminate a certain wrapper instance, w/o killing the others.