### PR TITLE
add single instance mode

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Piotr Miller
+Copyright (c) 2021-2022 Piotr Miller @ Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/nwg_wrapper/main.py
+++ b/nwg_wrapper/main.py
@@ -198,6 +198,11 @@ def main():
                         default=1,
                         help="initial Layer: 1 for bottom, 2 for top; 1 if no value given")
 
+    parser.add_argument("-si",
+                        "--single_instance",
+                        action="store_true",
+                        help="allow just Single program Instance")
+
     parser.add_argument("-sl",
                         "--sig_layer",
                         type=int,
@@ -235,6 +240,18 @@ def main():
 
     global args
     args = parser.parse_args()
+
+    if args.single_instance:
+        # Try and kill already running instance if any
+        pid_file = os.path.join(temp_dir(), "nwg-wrapper.pid")
+        if os.path.isfile(pid_file):
+            try:
+                pid = int(load_text_file(pid_file))
+                os.kill(pid, signal.SIGINT)
+                print("Running instance killed, PID {}".format(pid))
+            except:
+                pass
+        save_string(str(os.getpid()), pid_file)
 
     global layer
     layer = args.layer

--- a/nwg_wrapper/main.py
+++ b/nwg_wrapper/main.py
@@ -2,7 +2,7 @@
 
 """
 Wrapper to display a script output or a text file content on the desktop in sway or other wlroots-based compositors
-Author: Piotr Miller
+Copyright (c) 2021-2022 Piotr Miller & Contributors
 e-mail: nwg.piotr@gmail.com
 Project: https://github.com/nwg-piotr/nwg-wratter
 License: MIT

--- a/nwg_wrapper/tools.py
+++ b/nwg_wrapper/tools.py
@@ -49,6 +49,36 @@ def is_command(cmd):
         return False
 
 
+def temp_dir():
+    if os.getenv("TMPDIR"):
+        return os.getenv("TMPDIR")
+    elif os.getenv("TEMP"):
+        return os.getenv("TEMP")
+    elif os.getenv("TMP"):
+        return os.getenv("TMP")
+
+    return "/tmp"
+
+
+def load_text_file(path):
+    try:
+        with open(path, 'r') as file:
+            data = file.read()
+            return data
+    except Exception as e:
+        print(e)
+        return None
+
+
+def save_string(string, file):
+    try:
+        file = open(file, "wt")
+        file.write(string)
+        file.close()
+    except:
+        print("Error writing file '{}'".format(file))
+
+
 def list_outputs():
     """
     Get output names and geometry from i3 tree, assign to Gdk.Display monitors.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-wrapper',
-    version='0.1.1',
+    version='0.1.2',
     description='Wrapper to display script output or text file content on desktop in wlroots-based compositors',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Added `-si` | `--single_instance` mode. If used, the program on startup checks the pid file stored in /tmp dir and kills the process when started again.