### PR TITLE
Feature: spawn window instance invisible on launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ or:
 
 You can choose a different signal number with the `-sv | --sig_visibility` argument.
 
+Also, you can hide it on start with `-i` | `--invisible` argument and then show and hide it, using your specified or `USR2` signal.
+
 ### Custom quit signal
 
 Sometimes you may need to terminate a certain nwg-wrapper instance (see [#5](https://github.com/nwg-piotr/nwg-wrapper/issues/5)).

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ optional arguments:
                         Right Margin
   -l LAYER, --layer LAYER
                         initial Layer: 1 for bottom, 2 for top; 1 if no value given
+  -i, --invisible
+                        Make this instance of wrapper invisible on launch
   -sl SIG_LAYER, --sig_layer SIG_LAYER
                         Signal number for Layer switching; default: 10
   -sv SIG_VISIBILITY, --sig_visibility SIG_VISIBILITY

--- a/nwg_wrapper/main.py
+++ b/nwg_wrapper/main.py
@@ -198,6 +198,12 @@ def main():
                         default=1,
                         help="initial Layer: 1 for bottom, 2 for top; 1 if no value given")
 
+    parser.add_argument("-i",
+                        "--invisible",
+                        default=False,
+                        action=argparse.BooleanOptionalAction,
+                        help="Make this instance of wrapper invisible on launch")
+
     parser.add_argument("-si",
                         "--single_instance",
                         action="store_true",
@@ -339,7 +345,9 @@ def main():
         print("Using text file: {}".format(text_path))
         build_from_text(text_path, v_box, args.justify)
 
-    window.show_all()
+    if not args.invisible: 
+        window.show_all()
+
     window.connect('destroy', Gtk.main_quit)
 
     if script_path and args.refresh > 0:


### PR DESCRIPTION
In some cases i want to be able to spawn a wrapper window instance that is visibly hidden and show it only when i want, i.e. on nwg-panel executor left click.
This feature does just that, it adds a boolean flag, that when it passed, wrapper spawns visibly hidden.