### PR TITLE
Fix: Match documented behavior of --sig_layer

### DIFF
--- a/nwg_wrapper/main.py
+++ b/nwg_wrapper/main.py
@@ -47,7 +47,7 @@ def signal_handler(sig, frame):
         print("Terminated with a custom signal ({})".format(sig))
         Gtk.main_quit()
     elif sig == args.sig_layer:
-        layer = 2 if layer == 1 else 1
+        layer = args.layer if layer == 3 else 3
         GtkLayerShell.set_layer(window, layer)
     elif sig == args.sig_refresh:
         update_label_from_script(script_path, v_box, args.justify)


### PR DESCRIPTION
Currently, signalling nwg-wrapper with the configured layer signal will alternate its layer between layer 1 (bottom) and 2 (top) instead of between the provided `--layer` and 3 (overlay). This updates nwg-wrapper's behavior to match the documentation.

(Found this when `pkill -10 nwg-wrapper; swaylock "$@"; pkill -10 nwg-wrapper` didn't do what I expected.)