### PR TITLE
Generalize uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo python3 setup.py install --optimize=1
 ## To uninstall
 
 ```text
-rm -r /usr/lib/python3.9/site-packages/nwg_wrapper*
+rm -r /usr/lib/python3.*/site-packages/nwg_wrapper*
 rm /usr/bin/nwg-wrapper
 ```
 


### PR DESCRIPTION
Python version 3.x instead of just 3.9.