### PR TITLE
fix monitor match on gtk bug

### DIFF
--- a/nwg_wrapper/tools.py
+++ b/nwg_wrapper/tools.py
@@ -113,6 +113,8 @@ def list_outputs():
                 for line in lines:
                     if not line.startswith(" "):
                         name = line.split()[0]
+                    elif "Model" in line:
+                        model = line.split()[1]
                     elif "current" in line:
                         w_h = line.split()[0].split('x')
                         w = int(w_h[0])
@@ -123,6 +125,7 @@ def list_outputs():
                         y = int(x_y[1])
                         if name is not None and w is not None and h is not None and x is not None and y is not None:
                             outputs_dict[name] = {'name': name,
+                                                  'model': model,
                                                   'x': x,
                                                   'y': y,
                                                   'width': w,
@@ -135,9 +138,10 @@ def list_outputs():
     for i in range(display.get_n_monitors()):
         monitor = display.get_monitor(i)
         geometry = monitor.get_geometry()
+        model = monitor.get_model()
 
         for key in outputs_dict:
-            if int(outputs_dict[key]["x"]) == geometry.x and int(outputs_dict[key]["y"]) == geometry.y:
+            if outputs_dict[key]["model"] == model:
                 outputs_dict[key]["monitor"] = monitor
 
     return outputs_dict


### PR DESCRIPTION
Fix an issue regarding to the monitor matching mechanism. The root cause is the following bug in gtk. 
https://github.com/swaywm/sway/issues/8164  https://gitlab.gnome.org/GNOME/gtk/-/commit/51b04c5007f89142ed5a1ab240c03d5800b86b3d
A quick fix uses monitor's model attribute to do the match instead of geometry, as for now, the geometry.x and geometry.y will always be 0,0 regardless the real monitor position.